### PR TITLE
Adds flexibility to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Testing framework for the Coveo JavaScript Search Framework",
   "main": "./bin/js/CoveoJsSearchTests.js",
   "peerDependencies": {
-    "coveo-search-ui": "2.3477.x"
+    "coveo-search-ui": "^2.3477.1"
   },
   "scripts": {
     "precommit": "lint-staged",

--- a/src/Fake/FakeResults.ts
+++ b/src/Fake/FakeResults.ts
@@ -25,7 +25,8 @@ export function createFakeResults(
     _folded: undefined,
     termsToHighlight: undefined,
     phrasesToHighlight: undefined,
-    triggers: []
+    triggers: [],
+    searchAPIDuration: 288
   };
 }
 
@@ -58,7 +59,8 @@ export function createFakeResultsWithChildResults(
     _folded: undefined,
     termsToHighlight: undefined,
     phrasesToHighlight: undefined,
-    triggers: []
+    triggers: [],
+    searchAPIDuration: 288
   };
 }
 


### PR DESCRIPTION
Could not use v2.36[..] because of peer dependency errors. I added more flexibility to be able to use this lib in versions ranging from 2.3477.1 to 3.0.0 instead of 2.3477 to 2.3478